### PR TITLE
Added heroic flatpak support for linux

### DIFF
--- a/src/installfinders/linux/heroicFlatpak.ts
+++ b/src/installfinders/linux/heroicFlatpak.ts
@@ -1,0 +1,53 @@
+import fs from 'fs';
+import {
+  debug,
+} from '../../logging';
+import { SatisfactoryInstall } from '../../satisfactoryInstall';
+import { InstallFindResult } from '../baseInstallFinder';
+
+interface LegendaryGame {
+  app_name: string;
+  base_urls: string[];
+  can_run_offline: boolean;
+  egl_guid: string;
+  executable: string;
+  install_path: string;
+  install_size: number;
+  is_dlc: boolean;
+  launch_parameters: string;
+  manifest_path: string;
+  needs_verification: boolean;
+  requires_ot: boolean;
+  save_path: string;
+  title: string;
+  version: string;
+}
+
+interface LegendaryData {
+  [name: string]: LegendaryGame;
+}
+
+const HEROIC_DATA_PATH = `${process.env.HOME}/.var/app/com.heroicgameslauncher.hgl/config/legendary/installed.json`;
+
+export function getInstalls(): InstallFindResult {
+  const installs: Array<SatisfactoryInstall> = [];
+  const invalidInstalls: Array<string> = [];
+  if (fs.existsSync(HEROIC_DATA_PATH)) {
+    const heroicInstalls = JSON.parse(fs.readFileSync(HEROIC_DATA_PATH, 'utf8')) as LegendaryData;
+    Object.values(heroicInstalls).forEach((legendaryGame) => {
+      if (legendaryGame.app_name.includes('Crab')) {
+        installs.push(new SatisfactoryInstall(
+          `${legendaryGame.title} (Heroic-FlatPak)`,
+          legendaryGame.version,
+          legendaryGame.app_name.substring('Crab'.length),
+          legendaryGame.install_path,
+          `flatpak run com.heroicgameslauncher.hgl --no-gui --no-sandbox "heroic://launch/${legendaryGame.app_name}"`,
+        ));
+      }
+    });
+    return { installs, invalidInstalls };
+  }
+  debug('Heroic-Flatpak is not installed');
+
+  return { installs: [], invalidInstalls: [] };
+}

--- a/src/installfinders/linux/index.ts
+++ b/src/installfinders/linux/index.ts
@@ -3,11 +3,13 @@ import { getInstalls as getInstallsLutrisEpic } from './lutrisEpic';
 import { getInstalls as getInstallsLegendary } from './legendary';
 import { getInstalls as getInstallsSteam } from './steam';
 import { getInstalls as getInstallsSteamFlatpak } from './steamFlatpak';
+import { getInstalls as getInstallsHeroicFlatpak } from './heroicFlatpak';
 
 export async function getInstalls(): Promise<InstallFindResult> {
   const lutrisEpic = getInstallsLutrisEpic();
   const legendary = getInstallsLegendary();
   const steam = await getInstallsSteam();
   const steamFlatpak = await getInstallsSteamFlatpak();
-  return concatInstallFindResult(lutrisEpic, legendary, steam, steamFlatpak);
+  const heroicFlatpak = await getInstallsHeroicFlatpak();
+  return concatInstallFindResult(lutrisEpic, legendary, steam, steamFlatpak, heroicFlatpak);
 }


### PR DESCRIPTION
Hello, I've added Heroic Flatpak support so that the mod manager can detect installs. Heroic uses legendary underneath, so I was able to take the existing logic and convert it over to the Heroic paths in flatpak.